### PR TITLE
Adds lib and constants to the `MapboxDraw` namespace.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
-import runSetup from "./src/setup";
-import setupOptions from "./src/options";
-import setupAPI from "./src/api";
-import * as Constants from "./src/constants";
-import * as lib from "./src/lib";
+import * as Constants from './src/constants';
+import * as lib from './src/lib';
+
+import modes from './src/modes/index';
+import runSetup from './src/setup';
+import setupAPI from './src/api';
+import setupOptions from './src/options';
 
 const setupDraw = function (options, api) {
   options = setupOptions(options);
@@ -28,7 +30,6 @@ function MapboxDraw(options) {
   setupDraw(options, this);
 }
 
-import modes from "./src/modes/index";
 MapboxDraw.modes = modes;
 MapboxDraw.constants = Constants;
 MapboxDraw.lib = lib;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
-import runSetup from './src/setup';
-import setupOptions from './src/options';
-import setupAPI from './src/api';
-import * as Constants from './src/constants';
+import runSetup from "./src/setup";
+import setupOptions from "./src/options";
+import setupAPI from "./src/api";
+import * as Constants from "./src/constants";
+import * as lib from "./src/lib";
 
-const setupDraw = function(options, api) {
+const setupDraw = function (options, api) {
   options = setupOptions(options);
 
   const ctx = {
-    options
+    options,
   };
 
   api = setupAPI(ctx, api);
@@ -27,7 +28,9 @@ function MapboxDraw(options) {
   setupDraw(options, this);
 }
 
-import modes from './src/modes/index';
+import modes from "./src/modes/index";
 MapboxDraw.modes = modes;
+MapboxDraw.constants = Constants;
+MapboxDraw.lib = lib;
 
 export default MapboxDraw;

--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
+import runSetup from './src/setup';
+import setupOptions from './src/options';
+import setupAPI from './src/api';
 import * as Constants from './src/constants';
 import * as lib from './src/lib';
 
-import modes from './src/modes/index';
-import runSetup from './src/setup';
-import setupAPI from './src/api';
-import setupOptions from './src/options';
-
-const setupDraw = function (options, api) {
+const setupDraw = function(options, api) {
   options = setupOptions(options);
 
   const ctx = {
-    options,
+    options
   };
 
   api = setupAPI(ctx, api);
@@ -30,6 +28,7 @@ function MapboxDraw(options) {
   setupDraw(options, this);
 }
 
+import modes from './src/modes/index';
 MapboxDraw.modes = modes;
 MapboxDraw.constants = Constants;
 MapboxDraw.lib = lib;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,43 @@
+import * as CommonSelectors from "./common_selectors";
+import constrainFeatureMovement from "./constrain_feature_movement";
+import createMidPoint from "./create_midpoint";
+import createSupplementaryPoints from "./create_supplementary_points";
+import createVertex from "./create_vertex";
+import doubleClickZoom from "./double_click_zoom";
+import euclideanDistance from "./euclidean_distance";
+import featuresAt from "./features_at";
+import getFeatureAtAndSetCursors from "./get_features_and_set_cursor";
+import isClick from "./is_click";
+import isEventAtCoordinates from "./is_event_at_coordinates";
+import isTap from "./is_tap";
+import mapEventToBoundingBox from "./map_event_to_bounding_box";
+import ModeHandler from "./mode_handler";
+import moveFeatures from "./move_features";
+import sortFeatures from "./sort_features";
+import StringSet from "./string_set";
+import stringSetsAreEqual from "./string_sets_are_equal";
+import theme from "./theme";
+import toDenseArray from "./to_dense_array";
+
+export {
+  CommonSelectors,
+  constrainFeatureMovement,
+  createMidPoint,
+  createSupplementaryPoints,
+  createVertex,
+  doubleClickZoom,
+  euclideanDistance,
+  featuresAt,
+  getFeatureAtAndSetCursors,
+  isClick,
+  isEventAtCoordinates,
+  isTap,
+  mapEventToBoundingBox,
+  ModeHandler,
+  moveFeatures,
+  sortFeatures,
+  stringSetsAreEqual,
+  StringSet,
+  theme,
+  toDenseArray,
+};

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,24 +1,23 @@
-import * as CommonSelectors from './common_selectors';
-
-import ModeHandler from './mode_handler';
-import StringSet from './string_set';
-import constrainFeatureMovement from './constrain_feature_movement';
-import createMidPoint from './create_midpoint';
-import createSupplementaryPoints from './create_supplementary_points';
-import createVertex from './create_vertex';
-import doubleClickZoom from './double_click_zoom';
-import euclideanDistance from './euclidean_distance';
-import featuresAt from './features_at';
-import getFeatureAtAndSetCursors from './get_features_and_set_cursor';
-import isClick from './is_click';
-import isEventAtCoordinates from './is_event_at_coordinates';
-import isTap from './is_tap';
-import mapEventToBoundingBox from './map_event_to_bounding_box';
-import moveFeatures from './move_features';
-import sortFeatures from './sort_features';
-import stringSetsAreEqual from './string_sets_are_equal';
-import theme from './theme';
-import toDenseArray from './to_dense_array';
+import * as CommonSelectors from "./common_selectors";
+import constrainFeatureMovement from "./constrain_feature_movement";
+import createMidPoint from "./create_midpoint";
+import createSupplementaryPoints from "./create_supplementary_points";
+import createVertex from "./create_vertex";
+import doubleClickZoom from "./double_click_zoom";
+import euclideanDistance from "./euclidean_distance";
+import featuresAt from "./features_at";
+import getFeatureAtAndSetCursors from "./get_features_and_set_cursor";
+import isClick from "./is_click";
+import isEventAtCoordinates from "./is_event_at_coordinates";
+import isTap from "./is_tap";
+import mapEventToBoundingBox from "./map_event_to_bounding_box";
+import ModeHandler from "./mode_handler";
+import moveFeatures from "./move_features";
+import sortFeatures from "./sort_features";
+import StringSet from "./string_set";
+import stringSetsAreEqual from "./string_sets_are_equal";
+import theme from "./theme";
+import toDenseArray from "./to_dense_array";
 
 export {
   CommonSelectors,

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,23 +1,24 @@
-import * as CommonSelectors from "./common_selectors";
-import constrainFeatureMovement from "./constrain_feature_movement";
-import createMidPoint from "./create_midpoint";
-import createSupplementaryPoints from "./create_supplementary_points";
-import createVertex from "./create_vertex";
-import doubleClickZoom from "./double_click_zoom";
-import euclideanDistance from "./euclidean_distance";
-import featuresAt from "./features_at";
-import getFeatureAtAndSetCursors from "./get_features_and_set_cursor";
-import isClick from "./is_click";
-import isEventAtCoordinates from "./is_event_at_coordinates";
-import isTap from "./is_tap";
-import mapEventToBoundingBox from "./map_event_to_bounding_box";
-import ModeHandler from "./mode_handler";
-import moveFeatures from "./move_features";
-import sortFeatures from "./sort_features";
-import StringSet from "./string_set";
-import stringSetsAreEqual from "./string_sets_are_equal";
-import theme from "./theme";
-import toDenseArray from "./to_dense_array";
+import * as CommonSelectors from './common_selectors';
+
+import ModeHandler from './mode_handler';
+import StringSet from './string_set';
+import constrainFeatureMovement from './constrain_feature_movement';
+import createMidPoint from './create_midpoint';
+import createSupplementaryPoints from './create_supplementary_points';
+import createVertex from './create_vertex';
+import doubleClickZoom from './double_click_zoom';
+import euclideanDistance from './euclidean_distance';
+import featuresAt from './features_at';
+import getFeatureAtAndSetCursors from './get_features_and_set_cursor';
+import isClick from './is_click';
+import isEventAtCoordinates from './is_event_at_coordinates';
+import isTap from './is_tap';
+import mapEventToBoundingBox from './map_event_to_bounding_box';
+import moveFeatures from './move_features';
+import sortFeatures from './sort_features';
+import stringSetsAreEqual from './string_sets_are_equal';
+import theme from './theme';
+import toDenseArray from './to_dense_array';
 
 export {
   CommonSelectors,


### PR DESCRIPTION
This brings [a recent commit from the original repo](https://github.com/mapbox/mapbox-gl-draw/pull/1100/files), which exposes `lib` and `constants` on the `MapBoxDraw` namespace. These namespaces contain useful functions to help developments of custom modes.